### PR TITLE
Añade comando local en Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,7 @@
 
 run:
 	docker run --rm --volume `pwd`:/opt/app --env PYTHON_PATH=/opt/app -w /opt/app python:3.6-slim python3 main.py words.txt yes
+
+run-local:
+	python3 main.py words.txt yes
+	


### PR DESCRIPTION
Se añade una nueva directiva run-local al Makefile que permite ejecutar el script main.py directamente en el entorno local, sin necesidad de levantar un contenedor Docker.
